### PR TITLE
Fix bug

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -10,7 +10,7 @@ let vending = (options) => {
 };
 
 vending.create = (options) => {
-    if (!options.id || !parseInt(options.count)){
+    if (!options.id) {
         throw new Error("Missing url or count");
     }
 


### PR DESCRIPTION
Error is being thrown when count is set to 0, i.e all user's posts. Because of faulty if logic.

Allow it to default to 0. 

Use case is when I want to get all user posts. Without having to guess how many posts user has. There is a check elsewhere that fails if count is greater then user post count. 

In that case, if count is greater than user count, just return posts.